### PR TITLE
Improvement to performance of fastqread

### DIFF
--- a/src/fqfa/fastq/fastqread.py
+++ b/src/fqfa/fastq/fastqread.py
@@ -4,7 +4,6 @@
 
 from dataclasses import dataclass, field, InitVar
 from typing import List, Optional, ClassVar, Callable, Match
-from statistics import mean
 from fqfa.util.nucleotide import reverse_complement
 from fqfa.validator.create import create_validator
 from fqfa.constants.iupac.dna import DNA_BASES
@@ -99,7 +98,10 @@ class FastqRead:
             # mypy false positive: https://github.com/python/mypy/issues/5485
             raise ValueError("unexpected characters in sequence")
 
-        self.quality = [ord(c) - self.quality_encoding_value for c in quality_string]
+        quality_string_bytes = quality_string.encode('ascii')
+        qev = self.quality_encoding_value
+        self.quality = [qsb - qev for qsb in quality_string_bytes]
+
         if min(self.quality) < 0:
             raise ValueError("sequence quality value below 0")
         if max(self.quality) > 93:
@@ -139,7 +141,7 @@ class FastqRead:
             Mean quality value.
 
         """
-        return mean(self.quality)
+        return sum(self.quality)/len(self.quality)
 
     def min_quality(self) -> int:
         """Calculates and returns the read's minimum quality value.


### PR DESCRIPTION
These small changes make a big difference to the performance of fastq parsing and fastq average_quality.

Test code using real fastq data (derived from [PRJNA481326](https://www.ncbi.nlm.nih.gov/bioproject/PRJNA481326) and `cProfile` produces some big results ...

Before:
```
$ python test_fq.py | grep fastqread
   703265   17.817    0.000   24.007    0.000 fastqread.py:102(<listcomp>)
   703265    0.260    0.000   87.258    0.000 fastqread.py:133(average_quality)
   703265    1.424    0.000   29.066    0.000 fastqread.py:59(__post_init__)
```

After:
```
$ python test_fq.py | grep fastqread
   703265    5.047    0.000    5.047    0.000 fastqread.py:103(<listcomp>)
   703265    0.237    0.000    0.824    0.000 fastqread.py:135(average_quality)
   703265    1.244    0.000    9.637    0.000 fastqread.py:58(__post_init__)
```

The biggest difference is that `statistics.mean()`, as used in `average_quality` turns out to be very slow.
There's also a secondary improvement in the list comprehension.